### PR TITLE
Python 3.10 (match) based VFS

### DIFF
--- a/projects/cram/BUILD
+++ b/projects/cram/BUILD
@@ -1,5 +1,6 @@
 zapp_binary(
     name = "cram",
+    shebang = "/usr/bin/env /usr/bin/python3.10",
     main = "src/python/cram/__main__.py",
     imports = [
         "src/python"

--- a/projects/vfs/src/python/vfs/impl.py
+++ b/projects/vfs/src/python/vfs/impl.py
@@ -22,35 +22,31 @@ class Vfs(object):
             if not execute:
                 continue
 
-            elif e[0] == "exec":
-                _, dir, cmd = e
-                run(cmd, cwd=str(dir))
+            match e:
+                case ["exec", dir, cmd]:
+                    run(cmd, cwd=str(dir))
 
-            elif e[0] == "link":
-                _, src, dest = e
-                if dest.is_file() or dest.is_symlink():
-                    if dest.is_symlink() and dest.readlink() == src:
-                        continue
-                    else:
-                        dest.unlink()
+                case ["link", src, dest]:
+                    if dest.is_file() or dest.is_symlink():
+                        if dest.is_symlink() and dest.readlink() == src:
+                            continue
+                        else:
+                            dest.unlink()
 
-                assert not dest.exists()
-                dest.symlink_to(src)
+                    assert not dest.exists()
+                    dest.symlink_to(src)
 
-            elif e[0] == "copy":
-                raise NotImplementedError()
+                case ["copy", src, dest]:
+                    raise NotImplementedError()
 
-            elif e[0] == "chmod":
-                _, dest, mode = e
-                dest.chmod(mode)
+                case ["chmod", dest, mode]:
+                    dest.chmod(mode)
 
-            elif e[0] == "mkdir":
-                _, dest = e
-                dest.mkdir(exist_ok=True)
+                case ["mkdir", dest]:
+                    dest.mkdir(exist_ok=True)
 
-            elif e[0] == "unlink":
-                _, dest = e
-                dest.unlink()
+                case ["unlink", dest]:
+                    dest.unlink()
 
     def _append(self, msg):
         self._log.append(msg)


### PR DESCRIPTION
A PoC for adopting Python 3.10's `match` expression within the Vfs interpreter. This requires forcing the `cram` binary to use a 3.10 interpreter, which we can do by setting the `shebang=` parameter manually.

It'd be better to upgrade the global Python toolchain to 3.10 (which does just work), but we can't do that yet as some 3rdparty dependencies don't build under 3.10 yet.